### PR TITLE
Update some hardcoded paths for Allium

### DIFF
--- a/pico/cfg/onioncfg.json
+++ b/pico/cfg/onioncfg.json
@@ -32,8 +32,8 @@
   "bezel":{
     "current_bezel":0,
     "current_integer_bezel":0,
-    "bezel_path":"\/mnt\/SDCARD\/App\/pico\/res\/bezel\/standard",
-    "digit_path":"\/mnt\/SDCARD\/App\/pico\/res\/digit",
-    "bezel_int_path":"\/mnt\/SDCARD\/App\/pico\/res\/bezel\/integer_scaled"
+    "bezel_path":"\/mnt\/SDCARD\/Apps\/pico.pak\/res\/bezel\/standard",
+    "digit_path":"\/mnt\/SDCARD\/Apps\/pico.pak\/res\/digit",
+    "bezel_int_path":"\/mnt\/SDCARD\/Apps\/pico.pak\/res\/bezel\/integer_scaled"
   }
 }

--- a/pico/script/launch.sh
+++ b/pico/script/launch.sh
@@ -162,9 +162,9 @@ main() {
     echo performance > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
     curvol=$(get_curvol) 
     curmute=$(get_curmute)
-    mount --bind /mnt/SDCARD/Roms/PICO /mnt/SDCARD/App/pico/.lexaloffle/pico-8/carts
+    mount --bind /mnt/SDCARD/Roms/PICO /mnt/SDCARD/Apps/pico.pak/.lexaloffle/pico-8/carts
     start_pico
-    umount /mnt/SDCARD/App/pico/.lexaloffle/pico-8/carts
+    umount /mnt/SDCARD/Apps/pico.pak/.lexaloffle/pico-8/carts
     echo ondemand > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
 }
 


### PR DESCRIPTION
There are a few paths in the codebase still pointing at the OnionOS directory structure. Update these to point to Allium (/Apps/pico.pak)